### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ php:
   - 7.2
   - 7.3
 
+install:
+  - composer install
+
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
-sudo: false
+
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
-before_install: "composer install"
-script: "vendor/bin/phpunit"
+  - 7.1
+  - 7.2
+  - 7.3
+
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
- There's no point in testing in anything below PHP 7.1
- `sudo: false` is [long gone](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

Tests [seem to be passing](https://travis-ci.com/sanmai/freee-accounting-sdk-php/builds/135889312), albeit without any assertions.