### PR TITLE
Add .gitignore and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+/test export-ignore
+/samples export-ignore
+/docs export-ignore
+git_push.sh export-ignore
+config.json export-ignore
+.php_cs export-ignore
+/.openapi-generator export-ignore
+.openapi-generator-ignore export-ignore
+/.github export-ignore
+CONTRIBUTION_GUIDE.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock


### PR DESCRIPTION
.gitattributesでこう指定したファイルはcomposer install時には削除される。
インストールして使う時に不要なファイルを指定。

```
/test export-ignore
/samples export-ignore
```

例
https://github.com/laravel/socialite/blob/4.0/.gitattributes