### PR TITLE
2.1.2

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update lib version
         run: |
-          yq write -i .openapi-generator/config.yml artifactVersion v${{ github.event.pull_request.title }}
+          yq eval -i  '.artifactVersion = "v${{ github.event.pull_request.title }}"' .openapi-generator/config.yml
 
       - name: Generate APIs
         env:


### PR DESCRIPTION
github actions の実行で使われているyq コマンドがバージョン3系の書き方になっていたので、
バージョン4系の書き方に変更した

参考
https://mikefarah.gitbook.io/yq/v/v4.x/upgrading-from-v3#multiple-documents