### PR TITLE
guzzlehttp/guzzleの利用バージョンに7.xを追加した

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
guzzlehttp/guzzleの7.xを利用している環境でも追加できるように利用バージョンの設定を追加しました。