### PR TITLE
Fix openapitools/openapi-generator-cli version on 5.4.0 test

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   generate:
     name: Generate code and push them
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'auto-generate') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'auto-generate-test') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           SCHEMA_URL: https://raw.githubusercontent.com/freee/freee-api-schema/${{ steps.get_original_repo_tag.outputs.tag }}/_sdk_compatible/open-api-3/api-schema.yml
         run: |
-          docker run --rm -u "$(id -u $USER):$(id -g $USER)" -v "${PWD}:/local" openapitools/openapi-generator-cli:latest-release generate \
+          docker run --rm -u "$(id -u $USER):$(id -g $USER)" -v "${PWD}:/local" openapitools/openapi-generator-cli:v5.4.0 generate \
             -i ${{ env.SCHEMA_URL }} \
             -c /local/.openapi-generator/config.yml \
             -g php \


### PR DESCRIPTION
Generated by release dipatch

tag:v0.0.89